### PR TITLE
Fix first paragraph duplicating after enabling TOC on MySQL subtleties post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,7 +29,7 @@ layout: base
 
     {% if page.excerpt %}
       <p class="article__excerpt">
-        {{ page.excerpt }}
+        {{ page.excerpt | strip_html | strip_newlines }}
       </p>
     {% endif %}
   </header>

--- a/_posts/2018-05-04-mysql-subtleties.adoc
+++ b/_posts/2018-05-04-mysql-subtleties.adoc
@@ -4,6 +4,10 @@ title: A few MySQL subtleties and how to go about them
 date: 2018-05-04 00:00:00 +0200
 categories: Coding
 tags: Database MySQL SQL
+excerpt: >
+  A walkthrough of MySQL quirks and gotchas — division by zero returning NULL,
+  zero dates, ignored CHECK constraints, encoding traps, and more — and how to
+  work around them.
 ---
 :page-liquid:
 :toc:


### PR DESCRIPTION
## Summary

- Adding `:toc:` to the MySQL subtleties post caused `jekyll-asciidoc` to auto-derive `page.excerpt` from the document preamble. The layout rendered it above the TOC via `{% if page.excerpt %}`, while `{{ content }}` also included the same preamble paragraphs — producing visible duplication of the first paragraph.
- Added an explicit `excerpt:` to the MySQL post's YAML front-matter (matching the convention every other `.adoc` post in the repo already uses), overriding the auto-derived preamble.
- Applied `strip_html | strip_newlines` to `{{ page.excerpt }}` in `_layouts/post.html`, fixing the latent invalid HTML (`<p><div>...</div></p>`) that `jekyll-asciidoc`-rendered excerpts produce. Matches the idiom already used in `_includes/head.html`.

## Test plan

- [ ] Build locally with `bundle exec jekyll build`
- [ ] `grep -c 'MySQL is the most widely used database in the world' _site/blog/2018/05/04/mysql-subtleties/index.html` → **1** (no duplication)
- [ ] `grep -c 'id="toc"' _site/blog/2018/05/04/mysql-subtleties/index.html` → **1** (TOC intact)
- [ ] `grep -o '<p class="article__excerpt">.*</p>' _site/blog/2018/05/04/mysql-subtleties/index.html` → plain text, no nested tags
- [ ] Spot-check `_site/blog/2018/10/24/test-doubles-a-primer/index.html` excerpt — still plain text